### PR TITLE
Added SHA256 to the x509 Signing

### DIFF
--- a/site.sh
+++ b/site.sh
@@ -50,6 +50,7 @@ openssl req -new \
 openssl x509 -req -days $DAYS \
   -CA $ROOT_CRT -CAkey $ROOT_KEY \
   $CA_SERIAL \
+  -sha256 \
   -passin "file:$ROOT_PASS" \
   -extensions v3_req \
   -extfile site.ini \

--- a/star.sh
+++ b/star.sh
@@ -43,6 +43,7 @@ openssl req -new \
 openssl x509 -req -days $DAYS \
   -CA $ROOT_CRT -CAkey $ROOT_KEY \
   $CA_SERIAL \
+  -sha256 \
   -passin "file:$ROOT_PASS" \
   -extensions v3_req \
   -extfile star.ini \


### PR DESCRIPTION
Modern Browsers return the following error when trying to use the above script (which currently uses SHA1 by default)



![ERR_CERT_WEAK_SIGNATURE_ALGORITHM ](https://i1.wp.com/interbilgi.com/wp-content/uploads/2017/10/NETERR_CERT_WEAK_SIGNATURE_ALGORITHM.jpg?fit=850%2C491&ssl=1)

Adding the -sha256 flag fixes this issue.